### PR TITLE
feat: add mkdocs documentation and backstage catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: homerun2-light-catcher
+  description: Redis Streams consumer that triggers WLED light effects based on configurable YAML profiles
+  annotations:
+    github.com/project-slug: stuttgart-things/homerun2-light-catcher
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/homerun2-light-catcher/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/homerun2-light-catcher
+  tags:
+    - wled
+    - redis
+    - golang
+    - homerun2
+    - consumer
+    - alerting
+  links:
+    - url: https://github.com/stuttgart-things/homerun2-light-catcher
+      title: GitHub Repository
+      icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: platform-team
+  system: homerun2
+  dependsOn:
+    - resource:redis
+    - resource:wled

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,53 @@
+# CI/CD
+
+## GitHub Actions Workflows
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| **CI - Dagger Build & Test** | push/PR to main | Lint + build + integration test with Redis |
+| **Build, Push & Scan Container Image** | push/PR to main | ko image build, push, and Trivy scan |
+| **Run Repository Linting** | push/PR to main | Repository-wide linting |
+| **Release** | after image build succeeds, or manual | semantic-release, image staging, kustomize OCI push |
+
+## Dagger Functions
+
+The CI module in `dagger/main.go` provides:
+
+| Function | Description |
+|----------|-------------|
+| `Lint` | Run golangci-lint on source code |
+| `Build` | Compile Go binary |
+| `BuildImage` | Build container image with ko |
+| `ScanImage` | Scan image for vulnerabilities with Trivy |
+| `BuildAndTestBinary` | Build binary and run integration tests with Redis service |
+
+## Taskfile Commands
+
+| Task | Description |
+|------|-------------|
+| `task lint` | Run Go lint via Dagger |
+| `task build-test-binary` | Build and test binary with Redis via Dagger |
+| `task build-output-binary` | Build project binary |
+| `task build-scan-image-ko` | Build, push and scan container image |
+| `task run-wled-mock` | Run WLED mock server locally |
+| `task run-with-mock` | Run light-catcher with embedded WLED mock |
+| `task trigger-release` | Trigger Release workflow on GitHub Actions |
+| `task render-manifests-quick` | Render Kubernetes manifests |
+| `task push-kustomize-base` | Push kustomize base as OCI artifact |
+| `task release-local` | Full release pipeline (local, interactive) |
+| `task release-github` | Full release pipeline (CI, non-interactive) |
+
+## Release Process
+
+Releases are managed by [semantic-release](https://semantic-release.gitbook.io/) with conventional commits:
+
+- `feat:` triggers a minor version bump (e.g., 0.1.0 -> 0.2.0)
+- `fix:` triggers a patch version bump (e.g., 0.1.0 -> 0.1.1)
+
+The release pipeline:
+
+1. Determines next version from commit history
+2. Generates changelog
+3. Creates GitHub release
+4. Stages container image with version tag
+5. Pushes Kustomize base as OCI artifact

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,73 @@
+# Deployment
+
+## Container Image
+
+Images are built with [ko](https://ko.build/) (no Dockerfile). The image is published to:
+
+```
+ghcr.io/stuttgart-things/homerun2-light-catcher
+```
+
+## Kubernetes Manifests
+
+KCL templates in `kcl/` generate Kubernetes manifests. Render them with Dagger:
+
+```bash
+task render-manifests-quick
+```
+
+Or with custom parameters:
+
+```bash
+dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
+  --source "kcl" \
+  --parameters-file="tests/kcl-deploy-profile.yaml" \
+  export --path="/tmp/rendered-manifests.yaml"
+```
+
+## Kustomize OCI
+
+Release pipelines push a Kustomize base as an OCI artifact:
+
+```
+ghcr.io/stuttgart-things/homerun2-light-catcher-kustomize:<version>
+```
+
+Push manually:
+
+```bash
+task push-kustomize-base
+```
+
+## Flux Deployment
+
+Deploy as part of the homerun2 stack using Flux:
+
+```bash
+dagger call -m github.com/stuttgart-things/blueprints/kubernetes-deployment@v1.68.0 \
+  deploy --kubeconfig /path/to/kubeconfig --namespace homerun2
+```
+
+## Development
+
+### Run with Redis (via Dagger)
+
+```bash
+# Start Redis as a Dagger service
+task run-redis-as-service
+
+# In another terminal, run light-catcher with mock WLED
+task run-with-mock
+```
+
+### Redis CLI
+
+```bash
+task run-redis-cli
+```
+
+### Send a test message
+
+```bash
+redis-cli XADD messages '*' messageID test-msg-001
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,84 @@
+# Homerun2 Light Catcher
+
+Redis Streams consumer microservice that triggers WLED light effects based on configurable YAML profiles. Visual alerting for the homerun2 ecosystem.
+
+## Quick Start
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_ADDR` | `localhost` | Redis host |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_PASSWORD` | *(empty)* | Redis password |
+| `REDIS_STREAM` | `messages` | Redis stream to consume |
+| `CONSUMER_GROUP` | `homerun2-light-catcher` | Consumer group name |
+| `CONSUMER_NAME` | hostname | Consumer name |
+| `PROFILE_PATH` | `profile.yaml` | Path to WLED effect profile YAML |
+| `HEALTH_PORT` | `8080` | Health endpoint port |
+| `LOG_FORMAT` | `json` | Log format: `json` or `text` |
+| `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `MOCK_WLED` | *(empty)* | Set to any value to start embedded WLED mock |
+| `MOCK_WLED_PORT` | `9090` | Port for embedded WLED mock |
+
+### Run Locally (with embedded WLED mock)
+
+```bash
+MOCK_WLED=true \
+MOCK_WLED_PORT=9090 \
+PROFILE_PATH=tests/profile.yaml \
+LOG_FORMAT=text \
+REDIS_ADDR=localhost \
+go run .
+```
+
+### Run WLED Mock Standalone
+
+```bash
+go run ./cmd/wled-mock/
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check with build info |
+| GET | `/healthz` | Health check (alias) |
+
+## Architecture
+
+```
+Redis Stream --> RedisCatcher --+--> LogHandler (structured slog)
+                                +--> LightHandler
+                                       |
+                                 +-----+
+                                 v
+                           Profile YAML
+                           (system + severity -> effect)
+                                 |
+                                 v
+                           WLED HTTP API
+                           (or WLED Mock)
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `internal/catcher/` | Redis Stream consumer with Catcher interface |
+| `internal/profile/` | YAML profile loading and effect matching |
+| `internal/wled/` | WLED HTTP client (send effects, turn off) |
+| `internal/mock/` | WLED mock server with HTML dashboard |
+| `internal/config/` | Env var loading, slog setup |
+| `internal/handlers/` | Health endpoint |
+| `cmd/wled-mock/` | Standalone WLED mock binary |
+
+### Tech Stack
+
+- **Language**: Go 1.25+
+- **Consumer**: Redis Streams via `redisqueue` (consumer groups)
+- **Library**: `homerun-library/v2` for shared types, Redis JSON, helpers
+- **WLED**: HTTP client for WLED JSON API (`/json/state`)
+- **Build**: ko (no Dockerfile)
+- **CI**: Dagger modules, Taskfile
+- **Deploy**: KCL manifests, Kustomize, Kubernetes

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,106 @@
+# Effect Profiles
+
+Light Catcher uses YAML profiles to map incoming messages to WLED light effects. Each effect entry matches on system and severity to determine which WLED effect, color palette, and duration to apply.
+
+## Profile Structure
+
+```yaml
+effects:
+  <effect-name>:
+    systems:
+      - <system-name or "*" for all>
+    severity:
+      - <severity-level>
+    fx: <WLED effect name>
+    duration: <seconds>
+    color: <color palette name>
+    segments:
+      - <segment index>
+    endpoint: <WLED HTTP endpoint>
+```
+
+## Fields
+
+| Field | Description |
+|-------|-------------|
+| `systems` | List of source systems to match (e.g., `github`, `gitlab`). Use `"*"` for all. |
+| `severity` | List of severity levels to match (e.g., `ERROR`, `WARNING`, `INFO`, `SUCCESS`). |
+| `fx` | WLED effect name (e.g., `Blurz`, `DJ Light`, `Aurora`, `Twinkle`). |
+| `duration` | How long the effect runs in seconds before turning off. |
+| `color` | Color palette name (e.g., `sunset`, `ocean`, `forest`, `beach`). |
+| `segments` | WLED segment indices to apply the effect to. |
+| `endpoint` | WLED device HTTP endpoint (e.g., `http://192.168.1.100:80`). |
+
+## Example Profile
+
+```yaml
+effects:
+  error-git:
+    systems:
+      - gitlab
+      - github
+    severity:
+      - ERROR
+    fx: Blurz
+    duration: 3
+    color: sunset
+    segments:
+      - 0
+    endpoint: http://wled-device:80
+
+  info:
+    systems:
+      - "*"
+    severity:
+      - INFO
+    fx: DJ Light
+    duration: 3
+    color: ocean
+    segments:
+      - 0
+    endpoint: http://wled-device:80
+
+  success:
+    systems:
+      - "*"
+    severity:
+      - SUCCESS
+    fx: Aurora
+    duration: 3
+    color: forest
+    segments:
+      - 0
+    endpoint: http://wled-device:80
+
+  warning:
+    systems:
+      - "*"
+    severity:
+      - WARNING
+    fx: Twinkle
+    duration: 3
+    color: beach
+    segments:
+      - 0
+    endpoint: http://wled-device:80
+```
+
+## Matching Logic
+
+When a message arrives from a Redis Stream, the LightHandler:
+
+1. Extracts `system` and `severity` from the message payload
+2. Iterates through all profile effects
+3. Selects the first effect where the system matches (or `"*"`) and severity matches
+4. Sends the corresponding WLED effect via HTTP API
+5. Waits for the configured duration, then turns the effect off
+
+## WLED Mock
+
+For development and testing, use the embedded WLED mock server:
+
+```bash
+MOCK_WLED=true MOCK_WLED_PORT=9090 go run .
+```
+
+The mock provides an HTML dashboard at `http://localhost:9090` showing received effects in real time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Homerun2 Light Catcher
+site_description: Redis Streams consumer that triggers WLED light effects based on configurable YAML profiles
+
+nav:
+  - Home: index.md
+  - Effect Profiles: profiles.md
+  - Deployment: deployment.md
+  - CI/CD: cicd.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Add `mkdocs.yml` with techdocs-core plugin for Backstage TechDocs integration
- Add `catalog-info.yaml` for Backstage service catalog registration (component type, dependencies on redis + wled)
- Add `docs/index.md` — overview, environment variables, health endpoints, architecture diagram
- Add `docs/profiles.md` — WLED effect profile YAML structure, matching logic, mock usage
- Add `docs/deployment.md` — ko image builds, KCL manifests, Kustomize OCI, Flux deployment
- Add `docs/cicd.md` — GitHub Actions workflows, Dagger functions, Taskfile commands, release process

## Test plan
- [ ] `go test ./...` passes (no code changes)
- [ ] mkdocs renders correctly with `mkdocs serve`
- [ ] Backstage catalog import works with `catalog-info.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)