### PR TITLE
docs: document running modes and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,76 +41,109 @@ Available effects: Solid, Blink, Breathe, Wipe, Scan, Twinkle, Fireworks, Rainbo
 
 Color palettes: `sunset`, `beach`, `forest`, `ocean` — or single colors: `red`, `yellow`, `green`, `blue`, `white`
 
-## WLED Mock
+## Dashboards
 
-A built-in mock server with a live HTML dashboard for development — no real WLED hardware needed.
+Both the light-catcher and the WLED mock serve dashboards with the HOMERUN² design (Press Start 2P header, purple gradient, stuttgart-things footer).
 
-<details>
-<summary><b>Screenshot</b></summary>
+| Dashboard | URL | Shows |
+|-----------|-----|-------|
+| **Light Catcher** | `http://localhost:8080/` | Light event timeline with severity, system, effect, color |
+| **WLED Mock** | `http://localhost:9090/` (embedded) or `http://localhost:8080/` (standalone) | WLED state, segments, colors, event timeline with trigger context |
 
-The dashboard shows:
-- ON/OFF status with glow effect
-- Segment cards with effect name, speed, intensity
-- Color blocks that light up when active
-- Event timeline with timestamps
+The light-catcher dashboard shows events as they are triggered. The mock dashboard shows what the WLED device receives, including severity/system/effect metadata from the light-catcher.
 
-</details>
+## Running Modes
 
-<details>
-<summary><b>Run standalone</b></summary>
+### Production — with real WLED device
 
-```bash
-go run ./cmd/wled-mock/
-# Dashboard at http://localhost:8080
+Profile endpoints point to real WLED hardware. No mock needed.
+
+```yaml
+effects:
+  error:
+    systems: ["*"]
+    severity: [ERROR]
+    fx: Blurz
+    duration: 3
+    color: sunset
+    endpoint: http://192.168.1.100  # real WLED device
 ```
 
-</details>
+```bash
+REDIS_ADDR=redis-host PROFILE_PATH=profile.yaml go run .
+# Light-catcher dashboard at http://localhost:8080
+```
 
-<details>
-<summary><b>Run embedded with light-catcher</b></summary>
+### Development — with embedded mock
+
+Set `MOCK_WLED=true` to start the mock server inside the light-catcher process. Profile endpoints point to the embedded mock.
 
 ```bash
 MOCK_WLED=true MOCK_WLED_PORT=9090 \
 PROFILE_PATH=tests/profile.yaml \
 LOG_FORMAT=text REDIS_ADDR=localhost \
 go run .
+# Light-catcher dashboard at http://localhost:8080
 # Mock dashboard at http://localhost:9090
 ```
 
-</details>
+### Kubernetes — with standalone mock
+
+In Kubernetes, the mock runs as a separate deployment. Profile endpoints point to the mock's service DNS. Both are exposed via HTTPRoute with their own dashboards.
+
+```yaml
+# profile.yaml — endpoints point to mock service
+effects:
+  error:
+    systems: ["*"]
+    severity: [ERROR]
+    fx: Blurz
+    duration: 3
+    color: sunset
+    endpoint: http://homerun2-wled-mock.homerun2.svc.cluster.local
+```
+
+Deploy via Flux app (see [flux/apps/homerun2](https://github.com/stuttgart-things/flux/tree/main/apps/homerun2)):
+
+| Service | Image | Dashboard |
+|---------|-------|-----------|
+| light-catcher | `ghcr.io/stuttgart-things/homerun2-light-catcher` | `https://light-catcher.<DOMAIN>` |
+| wled-mock | `ghcr.io/stuttgart-things/homerun2-wled-mock` | `https://wled-mock.<DOMAIN>` |
+
+### WLED Mock Standalone
+
+Run the mock as a standalone binary for testing without Redis:
+
+```bash
+go run ./cmd/wled-mock/
+# Dashboard at http://localhost:8080
+```
+
+## Container Images
+
+Both images are built with [ko](https://ko.build) on top of `cgr.dev/chainguard/static` and published to GitHub Container Registry on every release.
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/stuttgart-things/homerun2-light-catcher:<tag>` | Main light-catcher service |
+| `ghcr.io/stuttgart-things/homerun2-wled-mock:<tag>` | Standalone WLED mock server |
+
+```bash
+docker pull ghcr.io/stuttgart-things/homerun2-light-catcher:<tag>
+docker pull ghcr.io/stuttgart-things/homerun2-wled-mock:<tag>
+```
 
 ## Deployment
 
 <details>
-<summary><b>Run locally</b></summary>
+<summary><b>Run locally (with Redis + embedded mock)</b></summary>
 
 ```bash
 # Start Redis (via Dagger)
 task run-redis-as-service
 
 # Run the light-catcher with embedded mock
-MOCK_WLED=true PROFILE_PATH=tests/profile.yaml \
-REDIS_ADDR=localhost LOG_FORMAT=text go run .
-```
-
-</details>
-
-<details>
-<summary><b>Container image (ko / ghcr.io)</b></summary>
-
-The container image is built with [ko](https://ko.build) on top of `cgr.dev/chainguard/static` and published to GitHub Container Registry.
-
-```bash
-# Pull the image
-docker pull ghcr.io/stuttgart-things/homerun2-light-catcher:<tag>
-
-# Run with Docker
-docker run \
-  -e REDIS_ADDR=redis -e REDIS_PORT=6379 \
-  -e REDIS_STREAM=messages \
-  -e PROFILE_PATH=/config/profile.yaml \
-  -v ./tests/profile.yaml:/config/profile.yaml:ro \
-  ghcr.io/stuttgart-things/homerun2-light-catcher:<tag>
+task run-with-mock
 ```
 
 </details>
@@ -140,14 +173,16 @@ internal/
   banner/                  # Animated startup banner (Bubble Tea)
   catcher/                 # Catcher interface (Redis consumer, handlers, mock)
   config/                  # Env-based config loading, slog setup
+  dashboard/               # Light event tracker + HTMX dashboard
   handlers/                # Health endpoint
   mock/                    # WLED mock server with HTML dashboard
   models/                  # CaughtMessage struct
   profile/                 # YAML profile loading, effect matching, color palettes
   wled/                    # WLED HTTP client
-dagger/                    # CI functions (Lint, Build, Test, Scan)
-kcl/                       # KCL deployment manifests (Kubernetes)
-tests/                     # Test data (profiles, deploy config, integration messages)
+dagger/                    # CI functions (Lint, Build, BuildMockImage, Test, Scan)
+kcl/                       # KCL deployment manifests (light-catcher)
+kcl-wled-mock/             # KCL deployment manifests (WLED mock)
+tests/                     # Test data (profiles, deploy config)
 ```
 
 </details>
@@ -262,7 +297,9 @@ config.healthPort: "8080"
 ## Links
 
 - [Releases](https://github.com/stuttgart-things/homerun2-light-catcher/releases)
-- [Container Images](https://github.com/stuttgart-things/homerun2-light-catcher/pkgs/container/homerun2-light-catcher)
+- [Light Catcher Image](https://github.com/stuttgart-things/homerun2-light-catcher/pkgs/container/homerun2-light-catcher)
+- [WLED Mock Image](https://github.com/orgs/stuttgart-things/packages/container/package/homerun2-wled-mock)
+- [Flux App](https://github.com/stuttgart-things/flux/tree/main/apps/homerun2) (Kubernetes deployment)
 - [homerun2-omni-pitcher](https://github.com/stuttgart-things/homerun2-omni-pitcher) (producer)
 - [homerun2-core-catcher](https://github.com/stuttgart-things/homerun2-core-catcher) (sibling consumer)
 - [homerun-library](https://github.com/stuttgart-things/homerun-library) (shared library)

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,33 @@ Redis Streams consumer microservice that triggers WLED light effects based on co
 | `MOCK_WLED` | *(empty)* | Set to any value to start embedded WLED mock |
 | `MOCK_WLED_PORT` | `9090` | Port for embedded WLED mock |
 
-### Run Locally (with embedded WLED mock)
+## Running Modes
+
+The light-catcher can run with a real WLED device or with a mock for development/testing.
+
+### Production — with real WLED device
+
+Profile endpoints point to real WLED hardware. The light-catcher dashboard at `/` shows triggered events.
+
+```yaml
+effects:
+  error:
+    systems: ["*"]
+    severity: [ERROR]
+    fx: Blurz
+    duration: 3
+    color: sunset
+    endpoint: http://192.168.1.100  # real WLED device
+```
+
+```bash
+REDIS_ADDR=redis-host PROFILE_PATH=profile.yaml go run .
+# Dashboard at http://localhost:8080
+```
+
+### Development — with embedded mock
+
+Set `MOCK_WLED=true` to start the mock inside the same process. Profile endpoints point to `http://localhost:9090`.
 
 ```bash
 MOCK_WLED=true \
@@ -30,20 +56,70 @@ PROFILE_PATH=tests/profile.yaml \
 LOG_FORMAT=text \
 REDIS_ADDR=localhost \
 go run .
+# Light-catcher dashboard at http://localhost:8080
+# Mock dashboard at http://localhost:9090
 ```
 
-### Run WLED Mock Standalone
+### Kubernetes — with standalone mock
+
+In Kubernetes, the mock runs as a separate deployment (`homerun2-wled-mock`). Profile endpoints point to the mock service DNS. Both services are exposed via HTTPRoute with their own dashboards.
+
+```yaml
+# profile endpoints point to mock service
+endpoint: http://homerun2-wled-mock.homerun2.svc.cluster.local
+```
+
+Deploy via [Flux app](https://github.com/stuttgart-things/flux/tree/main/apps/homerun2) with `light-catcher` and `wled-mock` components.
+
+### WLED Mock Standalone
+
+Run the mock without Redis for UI testing:
 
 ```bash
 go run ./cmd/wled-mock/
+# Dashboard at http://localhost:8080
 ```
+
+## Dashboards
+
+Both services serve HTMX dashboards with the HOMERUN² design.
+
+| Dashboard | Shows |
+|-----------|-------|
+| **Light Catcher** (`/`) | Event timeline with severity badges, system, effect, color |
+| **WLED Mock** (`/`) | WLED state, segment visualization, event timeline with trigger context (severity, system, effect from light-catcher) |
 
 ## Endpoints
 
+### Light Catcher
+
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/` | Light event dashboard |
+| GET | `/api/events` | JSON event list |
 | GET | `/health` | Health check with build info |
 | GET | `/healthz` | Health check (alias) |
+
+### WLED Mock
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | WLED state dashboard |
+| POST | `/json/state` | WLED JSON API (receives effects) |
+| GET | `/json/state` | Current WLED state |
+| GET | `/json/state/events` | State + event timeline |
+| GET | `/api/state` | API state with request count |
+| POST | `/api/reset` | Reset mock state |
+| GET | `/healthz` | Health check |
+
+## Container Images
+
+Both images are built with [ko](https://ko.build) and published on every release.
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/stuttgart-things/homerun2-light-catcher:<tag>` | Main light-catcher service |
+| `ghcr.io/stuttgart-things/homerun2-wled-mock:<tag>` | Standalone WLED mock server |
 
 ## Architecture
 
@@ -57,8 +133,8 @@ Redis Stream --> RedisCatcher --+--> LogHandler (structured slog)
                            (system + severity -> effect)
                                  |
                                  v
-                           WLED HTTP API
-                           (or WLED Mock)
+                           WLED HTTP API        Dashboard (/)
+                           (real or mock)       event timeline
 ```
 
 ### Components
@@ -66,6 +142,7 @@ Redis Stream --> RedisCatcher --+--> LogHandler (structured slog)
 | Component | Description |
 |-----------|-------------|
 | `internal/catcher/` | Redis Stream consumer with Catcher interface |
+| `internal/dashboard/` | Light event tracker and HTMX dashboard |
 | `internal/profile/` | YAML profile loading and effect matching |
 | `internal/wled/` | WLED HTTP client (send effects, turn off) |
 | `internal/mock/` | WLED mock server with HTML dashboard |
@@ -79,6 +156,6 @@ Redis Stream --> RedisCatcher --+--> LogHandler (structured slog)
 - **Consumer**: Redis Streams via `redisqueue` (consumer groups)
 - **Library**: `homerun-library/v2` for shared types, Redis JSON, helpers
 - **WLED**: HTTP client for WLED JSON API (`/json/state`)
-- **Build**: ko (no Dockerfile)
-- **CI**: Dagger modules, Taskfile
-- **Deploy**: KCL manifests, Kustomize, Kubernetes
+- **Build**: ko (no Dockerfile), two images per release
+- **CI**: Dagger modules, Taskfile, GitHub Actions
+- **Deploy**: KCL manifests, Kustomize OCI, Flux app


### PR DESCRIPTION
## Summary
- Document three running modes: production (real WLED), development (embedded mock), Kubernetes (standalone mock)
- Add dashboard section describing both light-catcher and mock UIs
- Add full endpoint reference for both services
- Document both container images built per release
- Update project structure with `dashboard/` and `kcl-wled-mock/`
- Add links to WLED mock image and Flux app

🤖 Generated with [Claude Code](https://claude.com/claude-code)