### PR TITLE
feat: PR-preview setup (Option B HTTPRoute + profile CM + 4 workflows)

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-light-catcher,homerun2-light-catcher-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,28 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    # Note: deliberately no `opened`. When a PR is created with `preview`
+    # already attached, GitHub fires both `opened` and `labeled` events
+    # back-to-back, and the comment template can't dedupe across two
+    # near-simultaneous runs — you end up with two URL comments. The
+    # `labeled` event handles the at-creation case just fine on its own.
+    types: [reopened, labeled]
+    branches:
+      - main
+
+jobs:
+  comment:
+    # `labeled`: post only when the just-added label is `preview` (the
+    # label the AppSet keys on). `reopened`: post only if the PR still
+    # has the `preview` label attached — `reopened` doesn't fire a
+    # `labeled` event, so we have to check the current label set.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'reopened' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: light-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: homerun2-light-catcher-pr
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-light-catcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret

--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -22,8 +22,15 @@ httproute = {
             }
     }
     spec: {
+        # group + kind are admission-webhook defaults on parentRefs; rendering
+        # them explicitly avoids drift on every reconcile (Gateway controller
+        # adds them in, ArgoCD compares chart-rendered against live and flags
+        # OutOfSync otherwise). Same shape as stuttgart-things/argocd#114 /
+        # stuttgart-things/homerun2-omni-pitcher#127.
         parentRefs: [
             {
+                group: "gateway.networking.k8s.io"
+                kind: "Gateway"
                 name: config.httpRouteParentRefName
                 if config.httpRouteParentRefNamespace:
                     namespace: config.httpRouteParentRefNamespace
@@ -41,10 +48,15 @@ httproute = {
                         }
                     }
                 ]
+                # group + kind + weight are admission defaults on backendRefs;
+                # rendering them explicitly prevents the same drift.
                 backendRefs: [
                     {
+                        group: ""
+                        kind: "Service"
                         name: config.name
                         port: config.servicePort
+                        weight: 1
                     }
                 ]
             }

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -18,6 +18,7 @@ _httpRouteParentRefName = option("config.httpRouteParentRefName")
 _httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
 _httpRouteHostname = option("config.httpRouteHostname")
 _httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_profileData = option("config.profileData")
 _extraEnvVars = option("config.extraEnvVars") or {}
 
 # Config instance with command-line overrides
@@ -48,6 +49,8 @@ config: schema.LightCatcher = schema.LightCatcher {
         httpRouteHostname = _httpRouteHostname
     if _httpRouteAnnotations:
         httpRouteAnnotations = _httpRouteAnnotations
+    if _profileData:
+        profileData = _profileData
     if _extraEnvVars:
         extraEnvVars = _extraEnvVars
 }

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -6,6 +6,7 @@ Imports all resources and exports manifests
 import namespace
 import serviceaccount
 import configmap
+import profile_configmap
 import secret
 import deploy
 import service
@@ -17,6 +18,7 @@ manifests = [
         namespace.namespace
         serviceaccount.serviceAccount
         configmap.configMap
+        profile_configmap.profileConfigMap
         secret.secretRedis
         deploy.deployment
         service.service

--- a/kcl/profile_configmap.k
+++ b/kcl/profile_configmap.k
@@ -1,0 +1,21 @@
+"""
+Profile ConfigMap for homerun2-light-catcher
+Contains the WLED effect rules YAML mounted at /config/profile.yaml
+"""
+
+import labels
+
+config = labels.config
+
+profileConfigMap = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: "{}-profile".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        "profile.yaml": config.profileData
+    }
+}

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -49,6 +49,65 @@ schema LightCatcher:
     # Profile path inside container
     profilePath: str = "/config/profile.yaml"
 
+    # Profile data (WLED effect rules YAML content). Rendered into the
+    # `<name>-profile` ConfigMap that the Deployment mounts at /config.
+    # Default endpoint targets `homerun2-wled-mock` so the kustomize OCI
+    # is self-contained against the wled-mock kustomize OCI's Service
+    # (same component pair as upstream; deployable side-by-side in a
+    # single namespace).
+    profileData: str = """\
+---
+effects:
+  error-git:
+    systems:
+      - gitlab
+      - github
+    severity:
+      - ERROR
+    fx: Blurz
+    duration: 3
+    color: sunset
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  info:
+    systems:
+      - "*"
+    severity:
+      - INFO
+    fx: DJ Light
+    duration: 3
+    color: ocean
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  success:
+    systems:
+      - "*"
+    severity:
+      - SUCCESS
+    fx: Aurora
+    duration: 3
+    color: forest
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  warning:
+    systems:
+      - "*"
+    severity:
+      - WARNING
+    fx: Twinkle
+    duration: 3
+    color: beach
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+"""
+
     # Extra environment variables
     extraEnvVars: {str:str} = {}
 

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -6,3 +6,12 @@ config.redisStream: messages
 config.consumerGroup: homerun2-light-catcher
 config.redisPassword: changeme # pragma: allowlist secret
 config.healthPort: "8080"
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-light-catcher.example.com


### PR DESCRIPTION
## Summary

- KCL httproute renders admission defaults (group/kind on parentRefs, group/kind/weight on backendRefs) so the live HTTPRoute matches what Cilium / Gateway API admission writes back — same fix as stuttgart-things/homerun2-omni-pitcher#127.
- Adds `profile_configmap.k` + `schema.profileData`. Default profile targets `http://homerun2-wled-mock`, so the published kustomize OCI is self-contained against the wled-mock OCI (no external profile ConfigMap required for the Deployment to boot).
- `tests/kcl-deploy-profile.yaml` flips `httpRouteEnabled: true` + parentRef so the kustomize OCI ships an HTTPRoute alongside the Service (Option B from stuttgart-things/argocd#116).
- 4 PR-preview workflows: `build-scan-image.yaml` gains a `build-pr` job (ko, tagged `pr-<num>-<sha>` + `pr-<num>`), plus new `push-kustomize-pr.yaml`, `cleanup-pr-artifacts.yaml`, `comment-preview-url.yaml`. Comment workflow keys on the `preview` label (matches the AppSet's pullRequest generator filter).

Companion catalog PR on stuttgart-things/argocd wires this into the `homerun2-pr-preview` platform: new AppSet co-tenanting light-catcher SUT + omni-pitcher (v1.11.1) + demo-pitcher (v1.8.1) + wled-mock (v0.3.0) + redis-stack, plus 4 Kyverno policy rows (quota, secrets, seed-data, sweep).

Tracker: stuttgart-things/homerun2-omni-pitcher#116 step 3 (one of the 6 remaining components).

Closes #16

## Test plan

- [ ] Open a no-op PR carrying the `preview` label after merge → verify:
  - [ ] `build-pr` publishes `ghcr.io/stuttgart-things/homerun2-light-catcher:pr-<num>-<sha>`
  - [ ] `push-kustomize-pr` publishes `oci://ghcr.io/stuttgart-things/homerun2-light-catcher-kustomize:pr-<num>-<sha>` with HTTPRoute alongside the Service
  - [ ] Comment bot posts the preview URL once (no duplicate from opened+labeled race)
  - [ ] Parent Application `homerun2-light-catcher-pr-<num>` Synced/Healthy with 5 children (light-catcher, omni-pitcher, demo-pitcher, wled-mock, redis-stack)
  - [ ] Live HTTPRoute matches rendered (no perpetual OutOfSync — verifies admission-defaults fix)
  - [ ] demo-pitcher UI → omni-pitcher → redis → light-catcher → wled-mock dashboard end-to-end
  - [ ] Close PR → namespace + GHCR `pr-<num>-*` versions cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)