### PR TITLE
fix: match severities case-insensitively + fix bundled profile

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -108,7 +109,9 @@ func LoadConfiguration(filepath string) (Configuration, error) {
 }
 
 // MatchEffect finds the first effect matching the given system and severity.
-// Systems support wildcard "*" to match any system.
+// Systems support wildcard "*" to match any system. Severity is matched
+// case-insensitively — homerun2 producers emit lowercase severities while
+// profiles are often authored in uppercase.
 func MatchEffect(config Configuration, system, severity string) (Effect, bool) {
 	for _, effect := range config.Effects {
 		systemMatch := false
@@ -121,7 +124,7 @@ func MatchEffect(config Configuration, system, severity string) (Effect, bool) {
 
 		severityMatch := false
 		for _, sev := range effect.Severity {
-			if sev == severity {
+			if strings.EqualFold(sev, severity) {
 				severityMatch = true
 				break
 			}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -123,6 +123,20 @@ func TestMatchEffect_NoMatch(t *testing.T) {
 	}
 }
 
+func TestMatchEffect_SeverityCaseInsensitive(t *testing.T) {
+	path := writeTestProfile(t)
+	config, _ := LoadConfiguration(path)
+
+	// Profile authored as "INFO"; producers emit lowercase "info".
+	effect, found := MatchEffect(config, "some-system", "info")
+	if !found {
+		t.Fatal("expected case-insensitive match for info → INFO")
+	}
+	if effect.Fx != "DJ Light" {
+		t.Errorf("expected DJ Light, got %s", effect.Fx)
+	}
+}
+
 func TestGetColor_Palette(t *testing.T) {
 	colors, err := GetColor("sunset")
 	if err != nil {

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -58,39 +58,15 @@ schema LightCatcher:
     profileData: str = """\
 ---
 effects:
-  error-git:
+  error:
     systems:
-      - gitlab
-      - github
+      - "*"
     severity:
-      - ERROR
+      - error
+      - critical
     fx: Blurz
     duration: 3
     color: sunset
-    segments:
-      - 0
-    endpoint: http://homerun2-wled-mock
-
-  info:
-    systems:
-      - "*"
-    severity:
-      - INFO
-    fx: DJ Light
-    duration: 3
-    color: ocean
-    segments:
-      - 0
-    endpoint: http://homerun2-wled-mock
-
-  success:
-    systems:
-      - "*"
-    severity:
-      - SUCCESS
-    fx: Aurora
-    duration: 3
-    color: forest
     segments:
       - 0
     endpoint: http://homerun2-wled-mock
@@ -99,10 +75,34 @@ effects:
     systems:
       - "*"
     severity:
-      - WARNING
+      - warning
     fx: Twinkle
     duration: 3
     color: beach
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  success:
+    systems:
+      - "*"
+    severity:
+      - success
+    fx: Aurora
+    duration: 3
+    color: forest
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  info:
+    systems:
+      - "*"
+    severity:
+      - info
+    fx: DJ Light
+    duration: 3
+    color: ocean
     segments:
       - 0
     endpoint: http://homerun2-wled-mock

--- a/tests/profile.yaml
+++ b/tests/profile.yaml
@@ -1,50 +1,50 @@
 ---
 effects:
-  error-git:
+  error:
     systems:
-      - gitlab
-      - github
+      - "*"
     severity:
-      - ERROR
+      - error
+      - critical
     fx: Blurz
     duration: 3
     color: sunset
     segments:
       - 0
-    endpoint: http://wled-mock:8080
-
-  info:
-    systems:
-      - "*"
-    severity:
-      - INFO
-    fx: DJ Light
-    duration: 3
-    color: ocean
-    segments:
-      - 0
-    endpoint: http://wled-mock:8080
-
-  success:
-    systems:
-      - "*"
-    severity:
-      - SUCCESS
-    fx: Aurora
-    duration: 3
-    color: forest
-    segments:
-      - 0
-    endpoint: http://wled-mock:8080
+    endpoint: http://homerun2-wled-mock
 
   warning:
     systems:
       - "*"
     severity:
-      - WARNING
+      - warning
     fx: Twinkle
     duration: 3
     color: beach
     segments:
       - 0
-    endpoint: http://wled-mock:8080
+    endpoint: http://homerun2-wled-mock
+
+  success:
+    systems:
+      - "*"
+    severity:
+      - success
+    fx: Aurora
+    duration: 3
+    color: forest
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock
+
+  info:
+    systems:
+      - "*"
+    severity:
+      - info
+    fx: DJ Light
+    duration: 3
+    color: ocean
+    segments:
+      - 0
+    endpoint: http://homerun2-wled-mock


### PR DESCRIPTION
## Summary

Smoke-testing the PR-preview env (#17) surfaced this: light-catcher consumes from Redis correctly but the wled-mock dashboard never lights up. Logs showed every event caught then dropped:

```
"message caught" ... "severity":"info","system":"pr-preview"
"no matching effect","system":"pr-preview","severity":"info"
```

### Root cause

1. `profile.MatchEffect` compared severity with a case-sensitive `==`. homerun2 producers (omni-pitcher, the preview seed Job) emit **lowercase** severities (`info`/`success`/`warning`/`critical`); the bundled profile was authored in **uppercase**. `severityToLevel` in `catcher/handlers.go` already accepted both cases — the codebase was internally inconsistent.
2. The bundled profile (`kcl/schema.k` `profileData` + `tests/profile.yaml`) had no `critical`/`error` entry, and `error-git` was scoped `systems: [gitlab, github]` — so `error`/`critical` from any other system never matched even with correct case.

### Fix

- `MatchEffect`: severity comparison → `strings.EqualFold` (case-insensitive). System match unchanged (exact + `*`).
- Bundled profile: replace `error-git` with an `error` effect covering `[error, critical]` scoped `systems: ["*"]`; lowercase all severities to match what producers send.
- New `TestMatchEffect_SeverityCaseInsensitive`.

Verified `go build ./...` + `go test ./...` green; `kcl run` renders the profile ConfigMap.

Closes #27

## Test plan

- [x] `go test ./...`
- [ ] After merge + release, rebase #17 (or open a fresh `preview`-labelled PR) → pitch an event via the demo UI → wled-mock dashboard lights up, light-catcher dashboard event count increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)