### PR TITLE
chore: exclude dagger/ from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignorePaths": [
+    "dagger/**"
   ]
 }


### PR DESCRIPTION
## Summary

`dagger/go.mod` + `dagger/go.sum` are generated by `dagger develop`; their dependency versions (the `dagger.io/dagger` SDK and its transitive deps — gqlparser, the otel packages + `replace` directives) are pinned to whatever the Dagger engine version expects.

Renovate keeps raising per-dependency bumps against `dagger/go.mod` — #23, #24, #26, and now #31. Each one drifts the CI module away from the engine-matched dependency set in isolation and can break it. The correct way to bump these is `dagger develop` after changing `engineVersion` in `dagger.json` (done in #30).

Adds `ignorePaths: ["dagger/**"]` so Renovate stops extracting dependencies from `dagger/` entirely.

Closes #32. Supersedes #31 — closing it (its otel `v0.16.0 → v0.19.0` bump would reintroduce engine drift; `v0.16.0` is what `dagger develop` for engine v0.20.8 produced).

## Test plan

- [ ] Renovate's next run raises no PRs against `dagger/go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)