### PR TITLE
docs: add homerun2-notification-catcher to Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ config.healthPort: "8080"
 - [Flux App](https://github.com/stuttgart-things/flux/tree/main/apps/homerun2) (Kubernetes deployment)
 - [homerun2-omni-pitcher](https://github.com/stuttgart-things/homerun2-omni-pitcher) (producer)
 - [homerun2-core-catcher](https://github.com/stuttgart-things/homerun2-core-catcher) (sibling consumer)
+- [homerun2-notification-catcher](https://github.com/stuttgart-things/homerun2-notification-catcher) (MS Teams / webhook consumer)
 - [homerun-library](https://github.com/stuttgart-things/homerun-library) (shared library)
 - [WLED Project](https://kno.wled.ge/)
 


### PR DESCRIPTION
## Summary
Adds the notification-catcher (MS Teams / webhook consumer for the `homerun.Message` stream) to the Links section, alongside the other sibling consumers it's wire-compatible with.

## Note for reviewers
This PR doubles as the verification trigger for **real Teams posting** on the platform-sthings notification-catcher — the dry-run flag was flipped off in stuttgart-things/stuttgart-things#2229. When the git-pitcher catches this PR-opened event (next poll cycle, max 5 min), the catcher should post an Adaptive Card to the configured Teams channel. Merging the doc improvement itself is on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)